### PR TITLE
Fixed minor css issue

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/layout/FloatingDiv.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/layout/FloatingDiv.java
@@ -123,11 +123,13 @@ public class FloatingDiv extends Div {
 			if(width < 250)
 				throw new IllegalArgumentException("The width=" + width + " is invalid: it cannot be smaller than 250.");
 			setWidth(width + "px");
+			setMinWidth(width + "px");
 		}
 		if(height > 0) {
 			if(height < 100)
 				throw new IllegalArgumentException("The height=" + height + " is invalid: it cannot be smaller than 100.");
 			setHeight(height + "px");
+			setMinHeight(height + "px");
 		}
 	}
 


### PR DESCRIPTION
When one sets the window dimensions, it is still possible to minimize the window in most browsers with help of the cursor. With setting the min height and width as well we prevent this problem. 