### PR TITLE
Initial commit for another error message div style

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/layout/ErrorMessageDiv.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/layout/ErrorMessageDiv.java
@@ -24,14 +24,15 @@
  */
 package to.etc.domui.component.layout;
 
-import java.util.*;
-
-import javax.annotation.*;
-
 import to.etc.domui.dom.css.*;
 import to.etc.domui.dom.errors.*;
 import to.etc.domui.dom.html.*;
 import to.etc.domui.util.*;
+
+import javax.annotation.*;
+import java.util.*;
+
+import static to.etc.domui.dom.css.VisibilityType.*;
 
 /**
  * This is the default in-component error handling panel, for components that
@@ -65,12 +66,12 @@ public class ErrorMessageDiv extends Div implements IErrorMessageListener {
 		}
 		DomUtil.getMessageFence(parent).addErrorListener(this);
 		setCssClass("ui-emd");
-		setVisibility(VisibilityType.HIDDEN);
+		setVisibility(HIDDEN);
 	}
 
 	public ErrorMessageDiv() {
 		setCssClass("ui-emd");
-		setVisibility(VisibilityType.HIDDEN);
+		setVisibility(HIDDEN);
 	}
 
 	public void setAsErrorFence(NodeContainer parent) {
@@ -114,6 +115,7 @@ public class ErrorMessageDiv extends Div implements IErrorMessageListener {
 	}
 
 	protected NodeContainer createErrorLine(UIMessage m) {
+		addAdditionalStyling(m);
 		Div d = new Div();
 		add(d);
 		d.setCssClass("ui-emd-msg ui-emd-" + m.getType().name().toLowerCase());
@@ -124,6 +126,14 @@ public class ErrorMessageDiv extends Div implements IErrorMessageListener {
 			errorNode.addCssClass("ui-input-err");
 		}
 		return d;
+	}
+
+	/**
+	 * Adds css selector for additional styling to div container.
+	 */
+	private void addAdditionalStyling(@Nonnull UIMessage m) {
+		if(getChildCount() >= 0 && getVisibility() == VISIBLE)
+			addCssClass("ui-emd-brd-" + m.getType().name().toLowerCase());
 	}
 
 	@Override
@@ -143,7 +153,7 @@ public class ErrorMessageDiv extends Div implements IErrorMessageListener {
 		}
 
 		if(getChildCount() == 0) {
-			setVisibility(VisibilityType.HIDDEN);
+			setVisibility(HIDDEN);
 		}
 	}
 }


### PR DESCRIPTION
The idea: wrap all error messages in another div that may contain additional styling. So, instead of providing various rows that have separate icon and text styling, style the whole div with underlying text rows. In order to be compatible with old/other DomUI styles, current styling is not changed.

One can 'activate' the additional styling by providing a fragment that contains content for the corresponding css class. So, in this preview, the fragment may look like:
```

/*** errormessages.frag.css ***/
/*** This stylesheet overrides DomUI's default styling for the ErrorMessageDiv, a helper ***/
/*** for components that handle their error display, with ViewPoint specific styling. ***/
html {
	height: 100%;
	width: 100%;
}
.ui-emd {
	border-radius: 2px;
	-webkit-border-radius: 2px;
	-moz-border-radius: 2px;
}
.ui-emd-msg {
	background-repeat: no-repeat;
	background-position: 10px;
	padding-left: 50px;
	background-size: 11px 11px;
}
.ui-emd-error {
	background-image: none;
	margin: 10px !important;
	padding-left: 50px !important;
}
.ui-emd-info {
	background-image: none;
	margin: 10px !important;
	padding-left: 50px !important;
}
.ui-emd-warning {
	background-image: none;
	margin: 10px !important;
	padding-left: 50px !important;
}
.ui-emd-brd-error {
	background-color: <%= red_bg %>;
	border: 1px solid <%= red_stroke %>;
	background-image: url(../../../../themes/vp-icons-clean/Default/32x32_error.png);
	background-repeat: no-repeat;
	background-position: 10px;
}
.ui-emd-brd-info {
	background-color: <%= navy_blue_bg %>;
	border: 1px solid <%= navy_blue_stroke %>;
	background-image: url(../../../../themes/vp-icons-clean/Default/32x32_info.png);
	background-repeat: no-repeat;
	background-position: 10px;
	margin: 10px !important;
	padding: 10px !important;
}
.ui-emd-brd-warning {
	background-color: <%= orange_bg %>;
	border: 1px solid <%= orange_stroke %>;
	background-image: url(../../../../themes/vp-icons-clean/Default/32x32_warning.png);
	background-repeat: no-repeat;
	background-position: 10px;
	margin: 10px !important;
	padding: 10px !important;
}
```
Please note that for .ui-emd-x the background-image is none. Eventually, you may have something like this:

![screenshot from 2017-10-25 14-29-03](https://user-images.githubusercontent.com/4572798/31998551-82943684-b990-11e7-93ff-f2062d45d495.png)
