### PR TITLE
add an INFO type MsgBox with an IAnswer parameter.

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/misc/MsgBox.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/misc/MsgBox.java
@@ -287,6 +287,16 @@ public class MsgBox extends Window {
 		message(dad, Type.INFO, string);
 	}
 
+	/**
+	 * Display some information; Call the onAnswer handler when 'Ok' is clicked.
+	 * @param dad
+	 * @param string
+	 * @param onAnswer
+	 */
+	public static void info(NodeBase dad, String string, final IAnswer onAnswer) {
+		message(dad, MsgBox.Type.INFO, string, onAnswer);
+	}
+
 	public static void warning(NodeBase dad, NodeContainer string) {
 		message(dad, Type.WARNING, string);
 	}


### PR DESCRIPTION
I need a callback after displaying a TYPE.info msgbox to the user. This allows for a forceRebuild() of the calling page without losing the msgbox altogether, for example.