### PR TITLE
Added way to handle response headers per registered page class name.

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/dom/html/Page.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/dom/html/Page.java
@@ -281,7 +281,7 @@ final public class Page implements IQContextContainer {
 		if(res == null)
 			throw new IllegalStateException("internal: missing domui NLS resource $js/domuinls{nls}.js");
 		addHeaderContributor(HeaderContributor.loadJavascript(res), -760);
-		m_HTTPHeaderMap.putAll(app.getDefaultHTTPHeaderMap());
+		m_HTTPHeaderMap.putAll(app.applyPageHeaderTransformations(pageContent.getClass().getName(), app.getDefaultHTTPHeaderMap()));
 	}
 
 

--- a/to.etc.domui/src/main/java/to/etc/domui/server/ApplicationRequestHandler.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/server/ApplicationRequestHandler.java
@@ -94,7 +94,8 @@ final public class ApplicationRequestHandler implements IFilterRequestHandler {
 			throw new IllegalStateException("Invalid TO url generated");
 
 		//-- Output all headers
-		DomApplication.get().getDefaultHTTPHeaderMap().forEach((header, value) -> rr.addHeader(header, value));
+		DomApplication domApplication = DomApplication.get();
+		domApplication.applyPageHeaderTransformations(ctx.getPageName(), domApplication.getDefaultHTTPHeaderMap()).forEach((header, value) -> rr.addHeader(header, value));
 
 		IBrowserOutput out = new PrettyXmlOutputWriter(ctx.getOutputWriter("text/html; charset=UTF-8", "utf-8"));
 		out.writeRaw("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" + "<html><head><script language=\"javascript\"><!--\n"

--- a/to.etc.domui/src/main/java/to/etc/domui/server/ApplicationRequestHandler.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/server/ApplicationRequestHandler.java
@@ -117,7 +117,8 @@ final public class ApplicationRequestHandler implements IFilterRequestHandler {
 		url = appendPersistedParameters(url, ctx);
 
 		//-- Output all headers
-		DomApplication.get().getDefaultHTTPHeaderMap().forEach((header, value) -> rr.addHeader(header, value));
+		DomApplication domApplication = DomApplication.get();
+		domApplication.applyPageHeaderTransformations(ctx.getPageName(), domApplication.getDefaultHTTPHeaderMap()).forEach((header, value) -> rr.addHeader(header, value));
 
 		IBrowserOutput out = new PrettyXmlOutputWriter(ctx.getOutputWriter("text/xml; charset=UTF-8", "utf-8"));
 		out.tag("redirect");

--- a/to.etc.domui/src/main/java/to/etc/domui/server/DomApplication.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/server/DomApplication.java
@@ -350,6 +350,25 @@ public abstract class DomApplication {
 	@NonNull
 	private volatile Map<String, String> m_defaultSiteHeaderMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
+	@NonNull
+	private final Map<String, Function<Map<String, String>, Map<String, String>>> m_pageHeaderTransformations = new HashMap<>();
+
+	protected <T extends UrlPage> void registerPageHeaderTransformations(Class<T> pageClass, Function<Map<String, String>, Map<String, String>> transformation) {
+		m_pageHeaderTransformations.put(pageClass.getName(), transformation);
+		System.err.println("Page " + pageClass.getName() + " registered for Response Header transformations");
+	}
+
+	public Map<String, String> applyPageHeaderTransformations(@Nullable String pageClassName, Map<String, String> headers) {
+		if(null == pageClassName) {
+			return headers;
+		}
+		Function<Map<String, String>, Map<String, String>> transformation = m_pageHeaderTransformations.get(pageClassName);
+		if(null == transformation) {
+			return headers;
+		}
+		return transformation.apply(headers);
+	}
+
 	/**
 	 * When > 0, TextArea components will automatically have their maxByteLength property
 	 * set to this value when they are created by a property factory. This should be set

--- a/to.etc.domui/src/main/java/to/etc/domui/server/ResponseCommandWriter.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/server/ResponseCommandWriter.java
@@ -26,7 +26,8 @@ public class ResponseCommandWriter {
 
 	private void renderHeaders(RequestContextImpl ctx) {
 		IRequestResponse rr = ctx.getRequestResponse();
-		DomApplication.get().getDefaultHTTPHeaderMap().forEach((header, value) -> rr.addHeader(header, value));
+		DomApplication domApplication = DomApplication.get();
+		domApplication.applyPageHeaderTransformations(ctx.getPageName(), domApplication.getDefaultHTTPHeaderMap()).forEach((header, value) -> rr.addHeader(header, value));
 	}
 
 	/**


### PR DESCRIPTION
Has to be done this way since there are cases when we redirect requests to target page classes before we have instance of such class.