### PR TITLE
delete Temp files on clear button pressed

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/upload/FileUpload2.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/upload/FileUpload2.java
@@ -49,6 +49,7 @@ import to.etc.domui.util.DomUtil;
 import to.etc.domui.util.Msgs;
 import to.etc.domui.util.upload.FileUploadException;
 import to.etc.domui.util.upload.UploadItem;
+import to.etc.util.FileTool;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -313,6 +314,7 @@ public class FileUpload2 extends Div implements IUploadAcceptingComponent, ICont
 	public void clear() throws Exception {
 		if(m_value == null)
 			return;
+		FileTool.closeAll(m_value.getFile());
 		setValue(null);
 		IValueChanged<FileUpload2> onValueChanged = (IValueChanged<FileUpload2>) getOnValueChanged();
 		if(null != onValueChanged)

--- a/to.etc.domui/src/main/java/to/etc/domui/component/upload/FileUploadMultiple.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/upload/FileUploadMultiple.java
@@ -49,6 +49,7 @@ import to.etc.domui.util.DomUtil;
 import to.etc.domui.util.Msgs;
 import to.etc.domui.util.upload.FileUploadException;
 import to.etc.domui.util.upload.UploadItem;
+import to.etc.util.FileTool;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -191,6 +192,7 @@ public class FileUploadMultiple extends Div implements IUploadAcceptingComponent
 		d.add(uploadItem.getRemoteFileName());
 		btn.setClicked(a -> {
 			m_value.remove(uploadItem);
+			FileTool.closeAll(uploadItem);
 			forceRebuild();
 		});
 	}
@@ -245,10 +247,10 @@ public class FileUploadMultiple extends Div implements IUploadAcceptingComponent
 		}
 	}
 
-	@Override public void setValue(@Nullable List<UploadItem> value) {
+	@Override
+	public void setValue(@Nullable List<UploadItem> value) {
 		if(value == null)
 			value = Collections.emptyList();
-
 		if(MetaManager.areObjectsEqual(m_value, value)) {
 			return;
 		}


### PR DESCRIPTION
When a file is uploaded using FileUpload2 or FileUploadMultiple and then cleared from the element using clear button, it will remain hanging in temp folder of server. 
This PR should fix that  