### PR TITLE
NullPointerException in Tree3 fix - adding null check before renderin…

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/tree3/Tree3.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/tree3/Tree3.java
@@ -599,7 +599,9 @@ public class Tree3<T> extends Div implements ITreeModelChangedListener<T> {
 		if(null == parentVn)
 			return;
 		Ul ul = parentVn.getChildRoot();
-		renderList(ul, parentVn);
+		if(null != ul) {
+			renderList(ul, parentVn);
+		}
 	}
 
 	@Nullable


### PR DESCRIPTION
 Adding null check before renderList call,  since it can cause NPE otherwise. 