### PR TITLE
method to set label before checkbox in CheckboxSetInputBase class

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInput.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInput.java
@@ -31,6 +31,12 @@ public class CheckboxSetInput<T> extends CheckboxSetInputBase<T, T> {
 		return this;
 	}
 
+	@Override
+	public CheckboxSetInput<T> labelBeforeCheckbox() {
+		super.labelBeforeCheckbox();
+		return this;
+	}
+
 	static public <T extends Enum<T>> CheckboxSetInput<T> create(Class<T> clz, T... exceptions) {
 		T[] ar = clz.getEnumConstants();
 		List<T> l = new ArrayList<>(ar.length);

--- a/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInputBase.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInputBase.java
@@ -113,6 +113,7 @@ abstract public class CheckboxSetInputBase<V, T> extends AbstractDivControl<Set<
 		Label span = new Label();
 		span.setForTarget((NodeBase) cb);
 		if(m_labelBeforeCheckbox) {
+			span.addCssClass("label-first");
 			pair.add(span);
 			pair.add((NodeBase) cb);
 		} else {

--- a/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInputBase.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInputBase.java
@@ -34,6 +34,8 @@ abstract public class CheckboxSetInputBase<V, T> extends AbstractDivControl<Set<
 
 	private boolean m_asButtons;
 
+	private boolean m_labelBeforeCheckbox;
+
 	@NonNull
 	abstract protected V listToValue(@NonNull T in) throws Exception;
 
@@ -105,13 +107,18 @@ abstract public class CheckboxSetInputBase<V, T> extends AbstractDivControl<Set<
 		boolean disa = isDisabled() || isReadOnly();
 		cb.setReadOnly(disa);
 
-		pair.add((NodeBase) cb);
 		IRenderInto<T> cr = m_actualContentRenderer;
 		if(cr == null)
 			cr = m_actualContentRenderer = calculateContentRenderer(lv);
 		Label span = new Label();
 		span.setForTarget((NodeBase) cb);
-		pair.add(span);
+		if(m_labelBeforeCheckbox) {
+			pair.add(span);
+			pair.add((NodeBase) cb);
+		} else {
+			pair.add((NodeBase) cb);
+			pair.add(span);
+		}
 		cr.render(span, lv);
 		m_checkMap.put(listval, cb);
 
@@ -183,6 +190,14 @@ abstract public class CheckboxSetInputBase<V, T> extends AbstractDivControl<Set<
 
 	protected CheckboxSetInputBase<V, T> asButtons() {
 		m_asButtons = true;
+		return this;
+	}
+
+	/**
+	 * Sets the label to appear before the checkbox. By default, the label is set to appear after the checkbox.
+	 */
+	protected CheckboxSetInputBase<V, T> labelBeforeCheckbox() {
+		m_labelBeforeCheckbox = true;
 		return this;
 	}
 

--- a/to.etc.domui/src/main/resources/resources/themes/scss/winter/_checkboxset.scss
+++ b/to.etc.domui/src/main/resources/resources/themes/scss/winter/_checkboxset.scss
@@ -1,5 +1,6 @@
 .ui-cbis {
 	display: inline;
+
 	.ui-cbis-c {
 		display: flex;
 		flex-direction: row;
@@ -10,7 +11,8 @@
 			display: flex;
 			align-items: center;
 		}
-		.ui-cbis-p label {
+
+		.ui-cbis-p .label-first {
 			margin-right: 4px;
 		}
 

--- a/to.etc.domui/src/main/resources/resources/themes/scss/winter/_checkboxset.scss
+++ b/to.etc.domui/src/main/resources/resources/themes/scss/winter/_checkboxset.scss
@@ -7,6 +7,11 @@
 
 		.ui-cbis-p {
 			padding-right: 10px;
+			display: flex;
+			align-items: center;
+		}
+		.ui-cbis-p label {
+			margin-right: 4px;
 		}
 
 		input, span, label {


### PR DESCRIPTION
﻿Ability to set the labels for each checkbox  on the left side of the toggle.
﻿The spacing between two filters and their belonging labels are made bigger so it is more clear which label refers to which toggle.