### PR TITLE
Moved handling of single shot messages to url page and added support …

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/dom/html/Div.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/dom/html/Div.java
@@ -24,6 +24,7 @@
  */
 package to.etc.domui.dom.html;
 
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import org.eclipse.jdt.annotation.NonNull;
 import to.etc.domui.server.RequestContextImpl;
 import to.etc.domui.util.IDragHandler;
@@ -77,6 +78,7 @@ public class Div extends NodeContainer implements IDropTargetable, IDraggable, I
 	}
 
 	@Override
+	@OverridingMethodsMustInvokeSuper
 	protected void afterCreateContent() throws Exception {
 		m_miniTableBuilder = null;
 	}

--- a/to.etc.domui/src/main/java/to/etc/domui/dom/html/UrlPage.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/dom/html/UrlPage.java
@@ -284,10 +284,17 @@ public class UrlPage extends AbstractPage {
 	@OverridingMethodsMustInvokeSuper
 	protected void afterCreateContent() throws Exception {
 		super.afterCreateContent();
-		handleSessionUIMessages(UIContext.getRequestContext().getWindowSession());
+		internalHandleSessionUIMessages(UIContext.getRequestContext().getWindowSession());
 	}
 
-	public void handleSessionUIMessages(WindowSession windowSession) throws Exception {
+	/**
+	 * Shows the single shot UI Message(s) if any are registered inside the session.
+	 * If such are found and shown, they are also removed from the session - as single shot means show it once and then clear it.
+	 *
+	 * @param windowSession stores the single shot messages
+	 * @throws Exception
+	 */
+	public void internalHandleSessionUIMessages(WindowSession windowSession) throws Exception {
 		List<UIMessage> ml = (List<UIMessage>) windowSession.getAttribute(UIGoto.SINGLESHOT_MESSAGE);
 		if(ml != null) {
 			if(!ml.isEmpty()) {
@@ -298,7 +305,6 @@ public class UrlPage extends AbstractPage {
 						DomUtil.USERLOG.debug(cid + ": page reload message = " + m.getMessage());
 					}
 
-					//page.getBody().addGlobalMessage(m);
 					MessageFlare mf = MessageFlare.display(this, m);
 					mf.setTestID("SingleShotMsg");
 				}
@@ -307,4 +313,3 @@ public class UrlPage extends AbstractPage {
 		}
 	}
 }
-

--- a/to.etc.domui/src/main/java/to/etc/domui/dom/html/UrlPage.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/dom/html/UrlPage.java
@@ -37,6 +37,7 @@ import to.etc.domui.dom.html.Page.AsyncMessageLink;
 import to.etc.domui.logic.ILogicContext;
 import to.etc.domui.logic.LogicContextImpl;
 import to.etc.domui.server.DomApplication;
+import to.etc.domui.server.IRequestContext;
 import to.etc.domui.server.RequestContextImpl;
 import to.etc.domui.state.UIContext;
 import to.etc.domui.state.UIGoto;
@@ -284,7 +285,10 @@ public class UrlPage extends AbstractPage {
 	@OverridingMethodsMustInvokeSuper
 	protected void afterCreateContent() throws Exception {
 		super.afterCreateContent();
-		internalHandleSessionUIMessages(UIContext.getRequestContext().getWindowSession());
+		IRequestContext requestContext = UIContext.internalGetContext();
+		if(null != requestContext) {
+			internalHandleSessionUIMessages(requestContext.getWindowSession());
+		}
 	}
 
 	/**

--- a/to.etc.domui/src/main/java/to/etc/domui/dom/html/UrlPage.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/dom/html/UrlPage.java
@@ -24,20 +24,27 @@
  */
 package to.etc.domui.dom.html;
 
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import to.etc.domui.component.layout.BreadCrumb;
 import to.etc.domui.component.layout.Window;
 import to.etc.domui.component.layout.title.AppPageTitleBar;
+import to.etc.domui.component.misc.MessageFlare;
+import to.etc.domui.dom.errors.UIMessage;
 import to.etc.domui.dom.html.Page.AsyncMessageLink;
 import to.etc.domui.logic.ILogicContext;
 import to.etc.domui.logic.LogicContextImpl;
 import to.etc.domui.server.DomApplication;
 import to.etc.domui.server.RequestContextImpl;
 import to.etc.domui.state.UIContext;
+import to.etc.domui.state.UIGoto;
+import to.etc.domui.state.WindowSession;
 import to.etc.domui.themes.DefaultThemeVariant;
 import to.etc.domui.themes.IThemeVariant;
+import to.etc.domui.util.Constants;
+import to.etc.domui.util.DomUtil;
 import to.etc.webapp.query.IQDataContextSource;
 import to.etc.webapp.query.QContextManager;
 import to.etc.webapp.query.QDataContext;
@@ -271,6 +278,33 @@ public class UrlPage extends AbstractPage {
 	 */
 	public void redirectIn(String url, long milliseconds) {
 		appendJavascript("setTimeout(function() { window.location.href = \"" + url + "\"; }, " + milliseconds + ");");
+	}
+
+	@Override
+	@OverridingMethodsMustInvokeSuper
+	protected void afterCreateContent() throws Exception {
+		super.afterCreateContent();
+		handleSessionUIMessages(UIContext.getRequestContext().getWindowSession());
+	}
+
+	public void handleSessionUIMessages(WindowSession windowSession) throws Exception {
+		List<UIMessage> ml = (List<UIMessage>) windowSession.getAttribute(UIGoto.SINGLESHOT_MESSAGE);
+		if(ml != null) {
+			if(!ml.isEmpty()) {
+				build();
+				for(UIMessage m : ml) {
+					if(DomUtil.USERLOG.isDebugEnabled()) {
+						String cid = getPage().getPageParameters().getString(Constants.PARAM_CONVERSATION_ID, null);
+						DomUtil.USERLOG.debug(cid + ": page reload message = " + m.getMessage());
+					}
+
+					//page.getBody().addGlobalMessage(m);
+					MessageFlare mf = MessageFlare.display(this, m);
+					mf.setTestID("SingleShotMsg");
+				}
+			}
+			windowSession.setAttribute(UIGoto.SINGLESHOT_MESSAGE, null);
+		}
 	}
 }
 

--- a/to.etc.domui/src/main/java/to/etc/domui/server/PageRequestHandler.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/server/PageRequestHandler.java
@@ -352,7 +352,7 @@ final public class PageRequestHandler {
 			callNewPageBuiltListeners(page);
 			page.internalFullBuild();                            // Cause full build
 
-			handleSessionUIMessages(windowSession, page);        //  Handle stored messages in session
+			page.getBody().handleSessionUIMessages(windowSession);        //  Handle stored messages in session
 			page.callRequestStarted();
 
 			List<IGotoAction> al = (List<IGotoAction>) windowSession.getAttribute(UIGoto.PAGE_ACTION);
@@ -506,24 +506,6 @@ final public class PageRequestHandler {
 		}
 		page.setInjected(true);
 		return true;
-	}
-
-	private void handleSessionUIMessages(WindowSession windowSession, Page page) throws Exception {
-		List<UIMessage> ml = (List<UIMessage>) windowSession.getAttribute(UIGoto.SINGLESHOT_MESSAGE);
-		if(ml != null) {
-			if(!ml.isEmpty()) {
-				page.getBody().build();
-				for(UIMessage m : ml) {
-					if(DomUtil.USERLOG.isDebugEnabled())
-						DomUtil.USERLOG.debug(m_cid + ": page reload message = " + m.getMessage());
-
-					//page.getBody().addGlobalMessage(m);
-					MessageFlare mf = MessageFlare.display(page.getBody(), m);
-					mf.setTestID("SingleShotMsg");
-				}
-			}
-			windowSession.setAttribute(UIGoto.SINGLESHOT_MESSAGE, null);
-		}
 	}
 
 	private boolean isPageTagStillValid(@NonNull Page page) throws Exception {

--- a/to.etc.domui/src/main/java/to/etc/domui/server/PageRequestHandler.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/server/PageRequestHandler.java
@@ -5,13 +5,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import to.etc.domui.component.misc.InternalParentTree;
-import to.etc.domui.component.misc.MessageFlare;
 import to.etc.domui.component.misc.MsgBox;
 import to.etc.domui.dom.HtmlFullRenderer;
 import to.etc.domui.dom.IBrowserOutput;
 import to.etc.domui.dom.PrettyXmlOutputWriter;
 import to.etc.domui.dom.errors.IExceptionListener;
-import to.etc.domui.dom.errors.UIMessage;
 import to.etc.domui.dom.html.ClickInfo;
 import to.etc.domui.dom.html.IHasChangeListener;
 import to.etc.domui.dom.html.NodeBase;
@@ -352,7 +350,7 @@ final public class PageRequestHandler {
 			callNewPageBuiltListeners(page);
 			page.internalFullBuild();                            // Cause full build
 
-			page.getBody().handleSessionUIMessages(windowSession);        //  Handle stored messages in session
+			page.getBody().internalHandleSessionUIMessages(windowSession);        //  Handle stored messages in session
 			page.callRequestStarted();
 
 			List<IGotoAction> al = (List<IGotoAction>) windowSession.getAttribute(UIGoto.PAGE_ACTION);


### PR DESCRIPTION
…to handle them also inside after create content (for cases when we want to see flare after page force rebuild, i.e. after forceReloadData() is being called).