### PR TITLE
Data pager fix position

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/tbl/DataPager2.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/tbl/DataPager2.java
@@ -190,44 +190,58 @@ final public class DataPager2 extends Div implements IDataTablePager {
 		 * render page numbers. The basic group is: 3 at the start, 3 at the end, 5 in the middle, unless we have <= 10 pages
 		 * in which case we render all.
 		 *
-		 * 1 2 3 ... n-2 n-1 n n+1 n+2 ... np-2 np-1 np
+		 * 1 ... n-1 [n] n+1 ... np-1 np
 		 */
 		if(np <= 10) {
 			renderButtons(0, 0, 10);
 		} else {
-			int ci = renderButtons(0, 0, 3);        // First 3 buttons
+			int ci = renderButtons(0, 0, 1);
 
-			if(ci < np) {
-				//-- do we have a middle range?
-				int ms = cp - 2;
-				if(ms < ci)
-					ms = ci;
-				int me = cp + 3;            // exclusive bound
-				if(me > np)
-					me = np;
+			if(cp < 4) {
+				// [1] 2 3 4 ... 18 19 (Render 3 more pages: 2, 3, 4)
 
-				if(ms < me) {
-					if(ci < ms)
-						bd.add(Icon.faEllipsisH.createNode().css("ui-dp2-ellipsis"));
-					ci = ms;
+				int from = 1;
+				int to = 4;
 
-					//bd.add(" ... ");
+				// (pages 2, 3, 4)
+				renderButtons(ci, from, to);
 
-					ci = renderButtons(ci, ms, me);
+				// Add Ellipsis (Gap between page 4 and the final two pages)
+				bd.add(Icon.faEllipsisH.createNode().css("ui-dp2-ellipsis"));
+
+				// Render the last two pages  np-2 and  np-1
+				renderButtons(np - 2, np - 2, np);
+
+			} else if(cp <= np - 5) {
+				// --- ZONE Middle
+				// 1 ... 4 [5] 6 ... 19 (Render a 3-page cluster centered on cp)
+
+				bd.add(Icon.faEllipsisH.createNode().css("ui-dp2-ellipsis"));
+
+				// --- Centered Cluster (3 pages: cp-1, cp, cp+1) ---
+				int from = cp - 1;
+				int to = cp + 2;
+				ci = renderButtons(from, from, to);
+
+				// --- Trailing Ellipsis ---
+				if(ci < np - 2) {
+					bd.add(Icon.faEllipsisH.createNode().css("ui-dp2-ellipsis"));
 				}
 
-				//-- Now do the end range, if applicable
+				//-- Last Page
+				// Render the last page  np-1
 				if(ci < np) {
-					ms = np - 2;
-					if(ms < ci)
-						ms = ci;
-
-					if(ci < ms)
-						bd.add(Icon.faEllipsisH.createNode().css("ui-dp2-ellipsis"));
-
-					ci = ms;
-					ci = renderButtons(ci, ms, np);
+					renderButtons(np - 1, np - 1, np);
 				}
+
+			} else { // cp is np-5 or greater
+				// 1 ... 15 16 [17] 18 19 (Render the last 5 pages)
+
+				// --- Leading Ellipsis ---
+				bd.add(Icon.faEllipsisH.createNode().css("ui-dp2-ellipsis"));
+
+				int from = np - 5; // Start index for the last 5 pages (np -5, np-4, np-3, np-2, np-1)
+				renderButtons(from, from, np);
 			}
 		}
 

--- a/to.etc.domui/src/main/resources/resources/themes/scss/winter/_datapager2.scss
+++ b/to.etc.domui/src/main/resources/resources/themes/scss/winter/_datapager2.scss
@@ -4,14 +4,20 @@ $pager2-button-bg: $alt-button-bg !default
 
 // https://fvsch.com/styling-buttons/ is useful
 .ui-dp2 {
-	.ui-dp2-btn + .ui-dp2-btn {
-		margin-left: 10px;
-	}
+	//.ui-dp2-btn + .ui-dp2-btn {
+	//	margin-left: 10px;
+	//}
 
+	.ui-dp2-btn, span.ui-dp2-ellipsis {
+		margin-right: 10px;
+	}
 	span.ui-dp2-ellipsis {
-		display: inline-block;
-		height: 2.25em;
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		height: auto;
 		padding: $pager2-padding;
+		width: 5ch;
 	}
 
 	button, button.ui-sib2 {
@@ -75,5 +81,14 @@ $pager2-button-bg: $alt-button-bg !default
 		width: 16px;
 		height: 16px;
 		background: url(nav-overflow.png) no-repeat;
+	}
+
+	.ui-dp2-btn.ui-dp2-pn {
+		//font-family: monospace; // ensures 1 and 2 take same space
+		display: inline-flex; // for better vertical alignment
+		justify-content: center;
+		align-items: center;
+		width: 5ch;  // fixed width for all numeric buttons
+		text-align: center;
 	}
 }


### PR DESCRIPTION
This PR addresses layout instability. This PR prevent the 'Next' button from shifting position when the visible page list changes.
 1. CSS Optimization : Fixed Element Width

2. Fixed 7-Element layout on DataPager2

For the table of 19 pages this is how it looks like: 
Current Page | Buttons
-- | --
1 | [1] 2 3 4 … 18 19
2 | 1 [2] 3 4 … 18 19
3 | 1 2 [3] 4 … 18 19
4 | 1 2 3 [4] … 18 19
5 | 1 … 4 [5] 6 … 19
6 | 1 … 5 [6] 7 … 19
7 | 1 … 6 [7] 8 … 19
8 | 1 … 7 [8] 9 … 19
9 | 1 … 8 [9] 10 … 19
10 | 1 … 9 [10] 11 … 19
11 | 1 … 10 [11] 12 … 19
12 | 1 … 11 [12] 13 … 19
13 | 1 … 12 [13] 14 … 19
14 | 1 … 13 [14] 15 … 19
15 | 1 … 14 [15] 16 19
16 | 1 … 15 16 [17] 18 19
17 | 1 … 15 16 17 [18] 19
18 | 1 … 15 16 17 18 [19]
19 | 1 … 15 16 17 18 [19]

