### PR TITLE
Add noExport() support to ColumnDef to exclude columns from export

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/tbl/ColumnDef.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/tbl/ColumnDef.java
@@ -114,6 +114,11 @@ final public class ColumnDef<I, T> {
 	private IRenderInto<ColumnDef<I, T>> m_headerRenderer;
 
 	/**
+	 * When set, this column will be excluded from exports.
+	 */
+	private boolean m_noExport;
+
+	/**
 	 * A property that contains a value hint, which will be shown
 	 * as the hover (title=) of the cell when present.
 	 */
@@ -601,5 +606,18 @@ final public class ColumnDef<I, T> {
 	@Nullable
 	public IRenderInto<ColumnDef<I, T>> getHeaderRenderer() {
 		return m_headerRenderer;
+	}
+
+	/**
+	 * Mark this column as not exportable, so it will be skipped when exporting.
+	 */
+	@NonNull
+	public ColumnDef<I, T> noExport() {
+		m_noExport = true;
+		return this;
+	}
+
+	public boolean isNoExport() {
+		return m_noExport;
 	}
 }

--- a/to.etc.domui/src/main/java/to/etc/domui/util/exporters/RowRendererCellWrapper.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/util/exporters/RowRendererCellWrapper.java
@@ -30,7 +30,7 @@ final public class RowRendererCellWrapper<V> implements IExportColumn<V> {
 
 	@Nullable
 	static public <I, X, V> RowRendererCellWrapper<V> create(ColumnDef<I, X> c) {
-		if(c.isEditable() || c.getControlFactory() != null) {
+		if(c.isEditable() || c.getControlFactory() != null || c.isNoExport()) {
 			return null;
 		}
 		PropertyMetaModel<Object> pmm = (PropertyMetaModel<Object>) c.getPropertyMetaModel();


### PR DESCRIPTION
Add noExport() support to ColumnDef to exclude columns from export

ColumnDef now has a noExport flag that can be set via the chainable noExport() method. RowRendererCellWrapper.create() checks this flag and returns null for columns marked as noExport, causing them to be skipped during export.

This is useful for columns that only contain UI elements (e.g. action buttons) and have no meaningful data to export