### PR TITLE
feat: make duration formatting locale-aware (u vs h for hours)

### DIFF
--- a/common/to.etc.alg/src/main/java/to/etc/util/StringTool.java
+++ b/common/to.etc.alg/src/main/java/to/etc/util/StringTool.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
@@ -77,6 +78,11 @@ public class StringTool {
 	static private final long DAYS = 24L * 60 * 60;
 
 	static private final long HOURS = 60L * 60;
+
+	/** Returns "u" for Dutch (uur), "h" for other locales (hour). */
+	private static String hourSuffix(Locale locale) {
+		return "nl".equals(locale.getLanguage()) ? "u" : "h";
+	}
 
 	/**
 	 * JRE version as a packed integer: 1.4.2.1
@@ -704,6 +710,11 @@ public class StringTool {
 
 	@NonNull
 	static public String strDuration(long dlt) {
+		return strDuration(dlt, Locale.getDefault());
+	}
+
+	@NonNull
+	static public String strDuration(long dlt, Locale locale) {
 		StringBuilder sb = new StringBuilder();
 
 		if(dlt >= DAYS) {
@@ -713,7 +724,7 @@ public class StringTool {
 		}
 		if(dlt >= HOURS) {
 			sb.append(Long.toString(dlt / HOURS));
-			sb.append("u ");
+			sb.append(hourSuffix(locale)).append(" ");
 			dlt %= HOURS;
 		}
 		if(dlt >= 60) {
@@ -728,6 +739,11 @@ public class StringTool {
 
 	@NonNull
 	static public String strDurationMillis(long dlt) {
+		return strDurationMillis(dlt, Locale.getDefault());
+	}
+
+	@NonNull
+	static public String strDurationMillis(long dlt, Locale locale) {
 		StringBuilder sb = new StringBuilder();
 
 		int millis = (int) (dlt % 1000); // Get milliseconds,
@@ -746,7 +762,7 @@ public class StringTool {
 				if(sp)
 					sb.append(' ');
 				sb.append(v);
-				sb.append("u");
+				sb.append(hourSuffix(locale));
 				sp = true;
 			}
 			dlt %= HOURS;

--- a/to.etc.domui/src/main/java/to/etc/domui/converter/MsDurationConverter.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/converter/MsDurationConverter.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import to.etc.domui.trouble.UIException;
 import to.etc.domui.trouble.ValidationException;
 import to.etc.domui.util.Msgs;
+import to.etc.util.StringTool;
 
 import java.util.Locale;
 
@@ -42,7 +43,7 @@ public class MsDurationConverter implements IConverter<Long> {
 			return "";
 		if(in.longValue() < 0)
 			return "";
-		return strDurationMillis(in.longValue());
+		return StringTool.strDurationMillis(in.longValue(), loc);
 	}
 
 	@Override
@@ -120,60 +121,6 @@ public class MsDurationConverter implements IConverter<Long> {
 			ct++;
 			ms.accept();
 		}
-	}
-
-	static public String strDurationMillis(long dlt) {
-		StringBuilder sb = new StringBuilder();
-
-		int millis = (int) (dlt % 1000); // Get milliseconds,
-		dlt /= 1000; // Now in seconds,
-
-		boolean sp = false;
-		if(dlt >= DAYS) {
-			sb.append(dlt / DAYS);
-			sb.append("D");
-			dlt %= DAYS;
-			sp = true;
-		}
-		if(dlt >= HOURS) {
-			long v = dlt / HOURS;
-			if(v != 0) {
-				if(sp)
-					sb.append(' ');
-				sb.append(v);
-				sb.append("u");
-				sp = true;
-			}
-			dlt %= HOURS;
-		}
-		if(dlt >= 60) {
-			long v = dlt / 60;
-			if(v != 0) {
-				if(sp)
-					sb.append(' ');
-				sb.append(v);
-				sb.append("m");
-				sp = true;
-			}
-			dlt %= 60;
-		}
-		if(dlt != 0) {
-			if(sp)
-				sb.append(' ');
-			sb.append(dlt);
-			sb.append("s");
-			sp = true;
-		}
-		if(millis != 0) {
-			if(sp)
-				sb.append(' ');
-			sb.append(millis);
-			sb.append("ms");
-		}
-		if(sb.length() == 0) {
-			sb.append("0s");
-		}
-		return sb.toString();
 	}
 
 }


### PR DESCRIPTION
Use locale to pick hour suffix: "u" for Dutch, "h" for others. Wire MsDurationConverter to StringTool and remove duplicate logic.