### PR TITLE
INSD-90 Fix CheckboxSetInput reset when defaultValue is a shared Set

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInputBase.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/input/CheckboxSetInputBase.java
@@ -145,6 +145,11 @@ abstract public class CheckboxSetInputBase<V, T> extends AbstractDivControl<Set<
 	//}
 
 	@Override
+	protected void internalSetValue(@Nullable Set<V> value) {
+		super.internalSetValue(value == null ? null : new HashSet<>(value));
+	}
+
+	@Override
 	public Set<V> internalGetValue() {
 		Set<V> value = super.internalGetValue();
 		if(null == value) {


### PR DESCRIPTION
The reset button doesn't clear checkboxes