### PR TITLE
INSD-155 Reject reversed date ranges in DateLookupControl

### DIFF
--- a/to.etc.domui/src/main/java/to/etc/domui/component/searchpanel/lookupcontrols/DateLookupControl.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/searchpanel/lookupcontrols/DateLookupControl.java
@@ -2,11 +2,13 @@ package to.etc.domui.component.searchpanel.lookupcontrols;
 
 import org.eclipse.jdt.annotation.Nullable;
 import to.etc.domui.component.input.DateInput2;
+import to.etc.domui.dom.errors.UIMessage;
 import to.etc.domui.dom.html.Div;
 import to.etc.domui.dom.html.IControl;
 import to.etc.domui.dom.html.IValueChanged;
 import to.etc.domui.dom.html.NodeBase;
 import to.etc.domui.dom.html.Span;
+import to.etc.domui.trouble.ValidationException;
 import to.etc.domui.util.Msgs;
 import to.etc.util.DateUtil;
 
@@ -55,12 +57,24 @@ public class DateLookupControl extends Div implements IControl<DatePeriod> {
 
 	@Override
 	public DatePeriod getValue() {
-		Date value = m_dateTo.getValue();
-		if(null != value && ! m_withTime) {
-			//in case of date only search add 1 day and truncate time, since date only search is inclusive for dateTo
-			value = DateUtil.addDays(value, 1);
+		Date from = m_dateFrom.getValue();
+		Date to = m_dateTo.getValue();
+		// Validate display dates before adding the inclusive +1 day to "until". Swapping after that
+		// adjustment produces a wrong exclusive upper bound (INSD-155).
+		if(from != null && to != null && from.getTime() > to.getTime()) {
+			ValidationException vx = new ValidationException(Msgs.uiLookupDateOrder);
+			m_dateTo.setMessage(UIMessage.error(vx));
+			throw vx;
 		}
-		return new DatePeriod(m_dateFrom.getValue(), value);
+		UIMessage toMessage = m_dateTo.getMessage();
+		if(toMessage != null && toMessage.getCode() == Msgs.uiLookupDateOrder) {
+			m_dateTo.setMessage(null);
+		}
+		if(null != to && !m_withTime) {
+			//in case of date only search add 1 day and truncate time, since date only search is inclusive for dateTo
+			to = DateUtil.addDays(to, 1);
+		}
+		return new DatePeriod(from, to);
 	}
 
 	@Override public void setValue(@Nullable DatePeriod v) {

--- a/to.etc.domui/src/main/java/to/etc/domui/component/searchpanel/lookupcontrols/DateLookupQueryBuilder.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/component/searchpanel/lookupcontrols/DateLookupQueryBuilder.java
@@ -6,7 +6,9 @@ import java.util.Date;
 
 /**
  * Given a {@link DatePeriod}, this adds the parts to the query that represent
- * that period.
+ * that period. From is inclusive, to is exclusive. {@link DateLookupControl}
+ * rejects a display range where from is after until before building the period
+ * (so the inclusive +1 day on until is not applied to a reversed range).
  *
  * @author <a href="mailto:jal@etc.to">Frits Jalvingh</a>
  * Created on 3-12-17.

--- a/to.etc.domui/src/main/java/to/etc/domui/util/Msgs.java
+++ b/to.etc.domui/src/main/java/to/etc/domui/util/Msgs.java
@@ -40,6 +40,9 @@ public enum Msgs implements IBundleCode {
 
 	uiLookupOpCombi, // = "ui.lookup.op.combi";
 
+	/** From date is after until date in a date range lookup */
+	uiLookupDateOrder,
+
 
 	/** CheckBoxButton **/
 	uiChkbbOn,

--- a/to.etc.domui/src/main/resources/to/etc/domui/util/messages.properties
+++ b/to.etc.domui/src/main/resources/to/etc/domui/util/messages.properties
@@ -44,6 +44,7 @@ ui.dpr.none=Deselecteer alle getoonde gegevens
 
 uiLookupInvalid=Opzoekwaarde niet geldig
 uiLookupOpCombi=Combinatie van opzoek-operators niet geldig
+uiLookupDateOrder=De begindatum mag niet na de einddatum liggen
 
 ui.lui.ttl=Opzoeken
 ui.lui.ttl.multi={0} record(s) geselecteerd

--- a/to.etc.domui/src/main/resources/to/etc/domui/util/messages_en.properties
+++ b/to.etc.domui/src/main/resources/to/etc/domui/util/messages_en.properties
@@ -43,6 +43,7 @@ ui.dpr.none=De-select all records shown
 
 uiLookupInvalid=Lookup value invalid
 uiLookupOpCombi=Lookup operations combination invalid
+uiLookupDateOrder=The from date must not be after the until date
 
 ui.lui.ttl=Lookup
 ui.lui.ttl.multi={0} record(s) selected 


### PR DESCRIPTION
Validate from <= until before the inclusive +1 day on until, so reversed ranges no longer produce wrong search results.